### PR TITLE
Ensure EXISTS key is not orphaned when expire is used

### DIFF
--- a/lib/redis/semaphore.rb
+++ b/lib/redis/semaphore.rb
@@ -36,7 +36,7 @@ class Redis
         if token == API_VERSION && @redis.get(version_key).nil?
           @redis.set(version_key, API_VERSION)
         end
-
+        set_expiration_if_necessary
         true
       end
     end
@@ -59,7 +59,6 @@ class Redis
     def lock(timeout = 0)
       exists_or_create!
       release_stale_locks! if check_staleness?
-
       token_pair = @redis.blpop(available_key, timeout)
       return false if token_pair.nil?
 
@@ -157,8 +156,6 @@ class Redis
     end
 
     def create!
-      @redis.expire(exists_key, 10)
-
       @redis.multi do
         @redis.del(grabbed_key)
         @redis.del(available_key)
@@ -167,7 +164,6 @@ class Redis
         end
         @redis.set(version_key, API_VERSION)
         @redis.persist(exists_key)
-
         set_expiration_if_necessary
       end
     end

--- a/spec/semaphore_spec.rb
+++ b/spec/semaphore_spec.rb
@@ -148,6 +148,31 @@ describe "redis" do
       sleep 3.0
       expect(@redis.keys.count).to eq(original_key_size)
     end
+
+    it "does not leave an exists key without an expiration when an expiration is specified" do
+      original_key_size = @redis.keys.count
+      queue = Queue.new
+      threads = 2.times.collect do
+        Thread.new do
+          Redis::Semaphore.new(:my_semaphore, :redis => @redis, :expiration => 3).lock(5) do
+            sleep 1
+          end
+        end
+      end
+      sleep 4.0
+      @redis2 = Redis.new :db => 15
+      threads.each{|t| t.kill } #ensure signal step fails
+      expect(@redis2.ttl("SEMAPHORE:my_semaphore:EXISTS").to_s).to_not eql("-1")
+      sleep 4.0 #allow blpop timeout to occur
+      thrd = Thread.new do
+        Redis::Semaphore.new(:my_semaphore, :redis => @redis2, :expiration => 3).lock(5) do
+          queue << "work"
+        end
+      end
+      thrd.join(3)
+      expect(queue.size).to eql(1)
+      expect(@redis.ttl("SEMAPHORE:my_semaphore:EXISTS").to_s).to_not eql("-1")
+    end
   end
 
   describe "semaphore without staleness checking" do


### PR DESCRIPTION
**TL;DR** - GETSET resets the TTL on a key to indefinite. We need to ensure a key always has a TTL if using `:expiration` 

-----
An observed and rare production (1 in a million) phenomenon has been a deadlock condition when timeouts on expiring locks are not used. Upon inspection of Redis, we could see that the EXPIRES key was present, but without a TTL and the AVAILABLE key was not. 

The problem occurs because in the fix for block syntax in b0bbfda39b4048fd130771cade651265bc1652ca removed setting the expiration explicitly when the `EXISTS` key already exists. IE ```token = @redis.getset(exists_key, EXISTS_TOKEN)``` returns a non-nil result. 


This is problematic because the `getset` resets the TTL. You can see this demonstrated in Redis:

```
127.0.0.1:6379[15]> getset 'foobar' '0'
(nil)
127.0.0.1:6379[15]> getset 'foobar' '0'
"0"
127.0.0.1:6379[15]> expire 'foobar' 999
(integer) 1
127.0.0.1:6379[15]> ttl 'foobar'
(integer) 996
127.0.0.1:6379[15]> getset 'foobar' '0'
"0"
127.0.0.1:6379[15]> ttl 'foobar'
(integer) -1
```

This now opens up the possibility that one process is in the critical section, a second process resets the TTL on the `EXISTS` key and then waits via `BLPOP` for the first process to complete. If somehow the `AVAILABLE` key expires, the second process will be waiting either indefinitely or until the lock times out. If the lock times out and is then retried, the `EXISTS` key will still be there forever and not expire, so it will again wait without completing. If the expiration is set explicitly after `GETSET` , then the retry will be successful after the expiration period because the semaphore will create a new set of keys.
